### PR TITLE
Fix code scanning alert no. 1: Binding a socket to all network interfaces

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -39,7 +39,7 @@ def find_available_port() -> int:
             sock = socket(AF_INET,
                           SOCK_STREAM)
 
-            sock.bind(("0.0.0.0",
+            sock.bind(("127.0.0.1",
                        port))
 
             # If the binding is successful,
@@ -73,7 +73,7 @@ def run_server() -> None:
         # Run Uvicorn with the chosen port and reload=True
         # to automatically restart if changes are made to the app code
         uvicorn.run("main:app",
-                    host = "0.0.0.0",
+                    host = "127.0.0.1",
                     reload = True,
                     port = port)
 


### PR DESCRIPTION
Fixes [https://github.com/P-Harvey/shyLLM/security/code-scanning/1](https://github.com/P-Harvey/shyLLM/security/code-scanning/1)

To fix the problem, we need to bind the socket to a specific network interface instead of all interfaces. This can be achieved by replacing "0.0.0.0" with the IP address of the dedicated interface. If the IP address of the dedicated interface is not known or needs to be configurable, we can modify the code to accept the IP address as an argument or read it from a configuration file.

In the provided code, we need to make changes in two places:
1. In the `find_available_port` function, replace "0.0.0.0" with the IP address of the dedicated interface.
2. In the `run_server` function, replace "0.0.0.0" with the IP address of the dedicated interface.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
